### PR TITLE
updates readme for vignette installation

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,8 @@ Suggests: coda(>= 0.19-4),
     akima,
     fields,
     pheatmap,
-    viridis
+    viridis,
+    rmarkdown
 VignetteBuilder: knitr
 LinkingTo: Rcpp, RcppArmadillo, BH
 Roxygen: list(markdown=TRUE)

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ R-package for analysis differential localisation experiments, include storage, c
 Users will require a working version of R, currently at least version >4. It is recommend to use RStudio. The package can then be installed using the `devtools` package. The package should take a few minutes to install on a regular desktop or laptop. The package will need to be loaded using `library(bandle)`
 
 ```{r,}
-devtools::install_github("ococrook/bandle")
+devtools::install_github("ococrook/bandle", build_vignettes = TRUE, dependencies = TRUE)
 ```
 
 # Examples
 
-A simple demo is given in the vigenettes folder with clear demonstrations of the input and output. A small dataset can take around an hour to run; for large dataset we recommend a a compute server. The longest the analysis has taken has been a couple of hours on a single compute node. The demo take a few minutes to run.
+A simple demo is given in the vigenettes folder with clear demonstrations of the input and output. A small dataset can take around an hour to run; for large dataset we recommend a compute server. The longest the analysis has taken has been a couple of hours on a single compute node. The demo take a few minutes to run.
 
 # Documentation
 


### PR DESCRIPTION
Currently, suggested installation will not install vignettes. Adding `build_vignettes=TRUE` to install command gives the following error 
```
Error: Failed to install 'bandle' from GitHub:
  System command 'R' failed, exit status: 1, stdout + stderr (last 10 lines):
E> --- re-building ‘bandle-vignette-getting-started.Rmd’ using rmarkdown
E> Error: processing vignette 'bandle-vignette-getting-started.Rmd' failed with diagnostics:
E> The 'rmarkdown' package should be installed and declared as a dependency of the 'bandle' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
E> --- failed re-building ‘bandle-vignette-getting-started.Rmd’
E> 
E> SUMMARY: processing the following file failed:
E>   ‘bandle-vignette-getting-started.Rmd’
E> 
E> Error: Vignette re-building failed.
E> Execution halted
```

This PR updates the recommended installation command to include vignettes and dependencies (e.g `pheatmap` required to build vignette).

